### PR TITLE
shutdown outside of the handler

### DIFF
--- a/example-app/README.md
+++ b/example-app/README.md
@@ -7,3 +7,12 @@ To run:
 bundle
 bundle exec clock
 ```
+
+To test invocation of existing signal handlers, put this code at the very top of exe/clock:
+
+```ruby
+Signal.trap('INT') do
+  puts "This is a well-behaving INT handler from outside of ruby-clock"
+  exit
+end
+```

--- a/exe/clock
+++ b/exe/clock
@@ -4,6 +4,7 @@ require 'ruby-clock'
 require "ruby-clock/dsl"
 RubyClock.detect_and_load_rails_app
 require 'rufus_monkeypatch'
+RubyClock.instance.listen_for_shutdown
 RubyClock.instance.listen_to_signals
 RubyClock.instance.prepare_rake
 RubyClock.instance.schedule.pause


### PR DESCRIPTION
because, i think but haven't totally verified, rufus will create
mutexts sometimes which is not allowed in a signal handler
